### PR TITLE
Add image build UI (wrap `container build`)

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -156,7 +156,7 @@ final class AppModel {
         case .runContainer, .containerLogs, .inspectContainer:
             select(.containers)
             pendingIntent = intent
-        case .pullImage, .runImage, .inspectImage:
+        case .pullImage, .buildImage, .runImage, .inspectImage:
             select(.images)
             pendingIntent = intent
         case .createVolume, .inspectVolume:

--- a/App/CommandPalette.swift
+++ b/App/CommandPalette.swift
@@ -18,6 +18,7 @@ enum AppIntent: Equatable, Hashable, Sendable {
     case runImage(reference: String)
     case inspectImage(id: String)
     case pullImage
+    case buildImage
     // Volumes / networks
     case inspectVolume(name: String)
     case createVolume
@@ -77,6 +78,10 @@ enum PaletteCatalog {
         out.append(.init(
             id: "action.pull", title: "Pull an image…", subtitle: "Download from a registry",
             systemImage: "arrow.down.circle.fill", category: .action, keywords: "fetch download", intent: .pullImage
+        ))
+        out.append(.init(
+            id: "action.build", title: "Build an image…", subtitle: "Build from a Dockerfile",
+            systemImage: "hammer.fill", category: .action, keywords: "dockerfile compile make", intent: .buildImage
         ))
         out.append(.init(
             id: "action.createVolume", title: "Create a volume…", subtitle: nil,

--- a/Core/Services/ImageService.swift
+++ b/Core/Services/ImageService.swift
@@ -1,6 +1,22 @@
 import Foundation
 
-/// Image management, backed by the `container image …` CLI subcommands.
+/// Options for `container build`, mapped to its flags.
+///
+/// Note: `build` is a *top-level* `container` subcommand (not `container image
+/// build`), but it produces an image, so it's surfaced here alongside the other
+/// image operations.
+struct BuildOptions: Sendable, Equatable {
+    var contextDirectory: String     // positional build context (a directory)
+    var tag: String?                 // -t/--tag — name for the built image
+    var dockerfilePath: String?      // -f/--file — path to Dockerfile
+    var buildArgs: [String] = []     // --build-arg KEY=VALUE (repeatable)
+    var labels: [String] = []        // --label KEY=VALUE (repeatable)
+    var noCache: Bool = false        // --no-cache
+    var target: String?              // --target <stage>
+}
+
+/// Image management, backed by the `container image …` CLI subcommands
+/// (plus the top-level `container build`).
 struct ImageService: Sendable {
     let cli: ContainerCLI
 
@@ -33,6 +49,20 @@ struct ImageService: Sendable {
         ["image", "prune"]
     }
 
+    static func buildArguments(_ options: BuildOptions) -> [String] {
+        // `--progress plain` gives line-oriented output we can stream/parse,
+        // matching how `pull` streams.
+        var args = ["build", "--progress", "plain"]
+        if let tag = options.tag, !tag.isEmpty { args += ["--tag", tag] }
+        if let file = options.dockerfilePath, !file.isEmpty { args += ["--file", file] }
+        for value in options.buildArgs { args += ["--build-arg", value] }
+        for value in options.labels { args += ["--label", value] }
+        if options.noCache { args.append("--no-cache") }
+        if let target = options.target, !target.isEmpty { args += ["--target", target] }
+        args.append(options.contextDirectory)
+        return args
+    }
+
     // MARK: Operations
 
     func list() async throws -> [ContainerImage] {
@@ -46,6 +76,11 @@ struct ImageService: Sendable {
     /// Pulls an image, streaming progress lines (mostly on stderr).
     func pull(reference: String) -> AsyncThrowingStream<StreamLine, Error> {
         cli.stream(Self.pullArguments(reference: reference))
+    }
+
+    /// Builds an image from a Dockerfile, streaming BuildKit progress lines.
+    func build(_ options: BuildOptions) -> AsyncThrowingStream<StreamLine, Error> {
+        cli.stream(Self.buildArguments(options))
     }
 
     @discardableResult

--- a/Features/Images/BuildImageView.swift
+++ b/Features/Images/BuildImageView.swift
@@ -1,0 +1,302 @@
+import SwiftUI
+import AppKit
+
+/// Sheet for `container build`: pick a context directory and (optionally) a
+/// Dockerfile, tag, build args, and target stage, then stream the build output.
+struct BuildImageView: View {
+    let service: ImageService
+    var onComplete: () async -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var contextDir = ""
+    @State private var dockerfile = ""
+    @State private var tag = ""
+    @State private var buildArgs = ""
+    @State private var labels = ""
+    @State private var target = ""
+    @State private var noCache = false
+
+    @State private var lines: [String] = []
+    @State private var isBuilding = false
+    @State private var finished = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    pathField(
+                        "Context directory", required: true,
+                        hint: "the build context sent to the builder",
+                        text: $contextDir, placeholder: "/path/to/project",
+                        choose: chooseContext, chooseDirectories: true
+                    )
+                    pathField(
+                        "Dockerfile", hint: "defaults to Dockerfile in the context",
+                        text: $dockerfile, placeholder: "optional — path to a Dockerfile",
+                        choose: chooseDockerfile, chooseDirectories: false
+                    )
+                    field("Tag", hint: "name for the built image") {
+                        TextField("optional — e.g. myapp:latest", text: $tag)
+                            .textFieldStyle(.roundedBorder)
+                            .disabled(isBuilding)
+                    }
+                    field("Build args", hint: "one KEY=VALUE per line") {
+                        editor($buildArgs, placeholder: "VERSION=1.2.3")
+                    }
+                    field("Labels", hint: "one KEY=VALUE per line") {
+                        editor($labels, placeholder: "team=infra")
+                    }
+                    field("Target stage", hint: "for multi-stage builds") {
+                        TextField("optional — e.g. builder", text: $target)
+                            .textFieldStyle(.roundedBorder)
+                            .disabled(isBuilding)
+                    }
+                    Toggle("Build without cache", isOn: $noCache)
+                        .toggleStyle(.checkbox)
+                        .font(Theme.Typography.callout)
+                        .disabled(isBuilding)
+
+                    if showConsole { consoleSection }
+                }
+                .padding(18)
+            }
+            .frame(height: 460)
+            Divider()
+            footer
+        }
+        .frame(width: 620)
+        .animation(Theme.Motion.spring, value: showConsole)
+    }
+
+    // MARK: - Header / footer
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "hammer.fill")
+                .font(.system(size: 17))
+                .foregroundStyle(Color.accentColor)
+            Text("Build an image").font(Theme.Typography.title)
+            Spacer()
+            CircleIconButton(systemImage: "xmark", help: "Close", size: 26) { dismiss() }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private var footer: some View {
+        HStack(spacing: 10) {
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                    .font(Theme.Typography.caption)
+                    .foregroundStyle(.red)
+                    .lineLimit(2)
+            } else if finished {
+                Label(tag.trimmedNonEmpty.map { "Built \($0)" } ?? "Build complete",
+                      systemImage: "checkmark.circle.fill")
+                    .font(Theme.Typography.caption)
+                    .foregroundStyle(.green)
+                    .lineLimit(1)
+            }
+            Spacer()
+            PillButton { dismiss() } label: { Text(finished ? "Done" : "Cancel") }
+            PillButton(style: .accent) {
+                Task { await build() }
+            } label: {
+                if isBuilding {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Label("Build", systemImage: "hammer.fill")
+                }
+            }
+            .disabled(!canBuild)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    // MARK: - Console
+
+    private var showConsole: Bool {
+        isBuilding || finished || errorMessage != nil || !lines.isEmpty
+    }
+
+    private var consoleSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                SectionLabel(title: "Build output")
+                Spacer()
+                if !lines.isEmpty {
+                    Text("\(lines.count) lines")
+                        .font(Theme.Typography.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            console.frame(height: 180)
+        }
+    }
+
+    private var console: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 1) {
+                    ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+                        Text(line.isEmpty ? " " : line)
+                            .font(Theme.Typography.monoCaption)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    Color.clear.frame(height: 1).id("bottom")
+                }
+                .padding(10)
+            }
+            .background(Color(nsColor: .textBackgroundColor), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .overlay {
+                if lines.isEmpty {
+                    Text(isBuilding ? "Starting build…" : "Build output appears here.")
+                        .font(Theme.Typography.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .onChange(of: lines.count) {
+                withAnimation(.easeOut(duration: 0.15)) { proxy.scrollTo("bottom", anchor: .bottom) }
+            }
+        }
+    }
+
+    // MARK: - Field helpers
+
+    @ViewBuilder private func field<Content: View>(
+        _ label: String,
+        required: Bool = false,
+        hint: String? = nil,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(spacing: 4) {
+                Text(label).font(Theme.Typography.caption)
+                if required { Text("*").foregroundStyle(.red).font(Theme.Typography.caption) }
+                if let hint {
+                    Text(hint).font(Theme.Typography.monoCaption).foregroundStyle(.tertiary)
+                }
+            }
+            content()
+        }
+    }
+
+    private func pathField(
+        _ label: String,
+        required: Bool = false,
+        hint: String? = nil,
+        text: Binding<String>,
+        placeholder: String,
+        choose: @escaping () -> Void,
+        chooseDirectories: Bool
+    ) -> some View {
+        field(label, required: required, hint: hint) {
+            HStack(spacing: 8) {
+                TextField(placeholder, text: text)
+                    .textFieldStyle(.roundedBorder)
+                    .disabled(isBuilding)
+                PillButton(action: choose) {
+                    Label("Browse…", systemImage: chooseDirectories ? "folder" : "doc")
+                }
+                .disabled(isBuilding)
+            }
+        }
+    }
+
+    private func editor(_ text: Binding<String>, placeholder: String) -> some View {
+        TextEditor(text: text)
+            .font(Theme.Typography.mono)
+            .scrollContentBackground(.hidden)
+            .padding(6)
+            .frame(height: 56)
+            .background(Theme.Palette.controlBackground, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+            .overlay(alignment: .topLeading) {
+                if text.wrappedValue.isEmpty {
+                    Text(placeholder)
+                        .font(Theme.Typography.mono)
+                        .foregroundStyle(.tertiary)
+                        .padding(.horizontal, 11)
+                        .padding(.vertical, 12)
+                        .allowsHitTesting(false)
+                }
+            }
+            .disabled(isBuilding)
+    }
+
+    // MARK: - Panels
+
+    private func chooseContext() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        if let dir = contextDir.trimmedNonEmpty { panel.directoryURL = URL(fileURLWithPath: dir) }
+        panel.prompt = "Select"
+        if panel.runModal() == .OK, let url = panel.url { contextDir = url.path }
+    }
+
+    private func chooseDockerfile() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        if let dir = contextDir.trimmedNonEmpty { panel.directoryURL = URL(fileURLWithPath: dir) }
+        panel.prompt = "Select"
+        if panel.runModal() == .OK, let url = panel.url { dockerfile = url.path }
+    }
+
+    // MARK: - Build
+
+    private var canBuild: Bool {
+        contextDir.trimmedNonEmpty != nil && !isBuilding
+    }
+
+    private func build() async {
+        isBuilding = true
+        finished = false
+        errorMessage = nil
+        lines = []
+        defer { isBuilding = false }
+
+        let options = BuildOptions(
+            contextDirectory: contextDir.trimmingCharacters(in: .whitespaces),
+            tag: tag.trimmedNonEmpty,
+            dockerfilePath: dockerfile.trimmedNonEmpty,
+            buildArgs: buildArgs.nonEmptyLines,
+            labels: labels.nonEmptyLines,
+            noCache: noCache,
+            target: target.trimmedNonEmpty
+        )
+
+        do {
+            for try await line in service.build(options) {
+                lines.append(line.text)
+            }
+            finished = true
+            await onComplete()
+        } catch let error as CLIError {
+            errorMessage = error.localizedDescription
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private extension String {
+    var trimmedNonEmpty: String? {
+        let trimmed = trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    var nonEmptyLines: [String] {
+        split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+}

--- a/Features/Images/ImagesScreen.swift
+++ b/Features/Images/ImagesScreen.swift
@@ -5,6 +5,7 @@ struct ImagesScreen: View {
     @Environment(AppModel.self) private var app
 
     @State private var showPull = false
+    @State private var showBuild = false
     @State private var tagTarget: ContainerImage?
     @State private var deleteTarget: ContainerImage?
     @State private var runTarget: ContainerImage?
@@ -19,6 +20,9 @@ struct ImagesScreen: View {
             SearchField(text: $model.searchText, prompt: "Search images")
             CircleIconButton(systemImage: "arrow.clockwise", help: "Refresh") {
                 Task { await model.load() }
+            }
+            PillButton { showBuild = true } label: {
+                Label("Build", systemImage: "hammer.fill")
             }
             PillButton(style: .accent) { showPull = true } label: {
                 Label("Pull", systemImage: "arrow.down.circle.fill")
@@ -41,6 +45,9 @@ struct ImagesScreen: View {
         }
         .sheet(isPresented: $showPull) {
             PullImageView(service: model.service) { await model.load() }
+        }
+        .sheet(isPresented: $showBuild) {
+            BuildImageView(service: model.service) { await model.load() }
         }
         .sheet(item: $tagTarget) { image in
             TagImageView(service: model.service, source: image.reference) { await model.load() }
@@ -73,6 +80,8 @@ struct ImagesScreen: View {
         switch intent {
         case .pullImage:
             showPull = true
+        case .buildImage:
+            showBuild = true
         case .runImage(let reference):
             guard let image = model.images.first(where: { $0.reference == reference }) else {
                 if listLoaded { app.clearIntent() }

--- a/Tests/ArgumentBuilderTests.swift
+++ b/Tests/ArgumentBuilderTests.swift
@@ -78,6 +78,40 @@ struct ArgumentBuilderTests {
         #expect(ImageService.pruneArguments() == ["image", "prune"])
     }
 
+    @Test func imageBuildMinimal() {
+        let options = BuildOptions(contextDirectory: ".")
+        #expect(ImageService.buildArguments(options) == ["build", "--progress", "plain", "."])
+    }
+
+    @Test func imageBuildFull() {
+        let options = BuildOptions(
+            contextDirectory: "/src/app",
+            tag: "myapp:latest",
+            dockerfilePath: "/src/app/Dockerfile",
+            buildArgs: ["VERSION=1.2.3", "ENV=prod"],
+            labels: ["team=infra"],
+            noCache: true,
+            target: "builder"
+        )
+        #expect(ImageService.buildArguments(options) == [
+            "build", "--progress", "plain",
+            "--tag", "myapp:latest",
+            "--file", "/src/app/Dockerfile",
+            "--build-arg", "VERSION=1.2.3",
+            "--build-arg", "ENV=prod",
+            "--label", "team=infra",
+            "--no-cache",
+            "--target", "builder",
+            "/src/app",
+        ])
+    }
+
+    @Test func imageBuildOmitsEmptyOptionalFlags() {
+        // Empty strings are treated as "unset" and must not emit bare flags.
+        let options = BuildOptions(contextDirectory: "ctx", tag: "", dockerfilePath: "", target: "")
+        #expect(ImageService.buildArguments(options) == ["build", "--progress", "plain", "ctx"])
+    }
+
     @Test func system() {
         #expect(SystemService.statusArguments() == ["system", "status", "--format", "json"])
         #expect(SystemService.dfArguments() == ["system", "df", "--format", "json"])


### PR DESCRIPTION
Closes #1.

Adds a **Build an image** flow so users can build from a Dockerfile without dropping to the terminal — the last big hole in the core build → run → iterate loop.

## What's included

- **`ImageService`** — `BuildOptions` + a pure, unit-tested `buildArguments(_:)` and a streaming `build(_:)`, mirroring the existing `pull` path (`--progress plain` for line-oriented output). Wraps the real top-level `container build` flags: `--tag`, `--file`, `--build-arg` (repeatable), `--label` (repeatable), `--no-cache`, `--target`, positional context directory last.
- **`BuildImageView`** — a sheet with:
  - Context-directory and Dockerfile pickers (`NSOpenPanel`, matching the Settings binary picker).
  - Tag, build args, labels, target stage, and a "build without cache" toggle.
  - A live streaming build console, reusing the `PullImageView` output pattern.
- **Wiring** — a **Build** toolbar button on the Images screen, a `⌘K` palette action ("Build an image…"), and pending-intent routing so the palette opens the sheet even on a freshly-mounted screen.
- **Tests** — `buildArguments` covered for the minimal case, the full-options path (flag ordering + repeatable flags), and empty-string flag omission.

## Verification

- `xcodebuild … test` — **97 tests pass** (3 new build-argument tests).
- `xcodebuild … build` — app target builds clean.
- Argv grounded against the actual `container build --help`, not guessed.
- Ran an adversarial multi-agent review over the diff (argv correctness, UI state, intent wiring, test coverage); no confirmed defects. One recurring observation — the `--label` flag was plumbed but not exposed in the UI — was addressed by adding the Labels field in this PR.

## Follow-ups (not in scope)

- "Rebuild & rerun" from a container whose image was built in-app.
- Dismissing the sheet mid-build doesn't cancel the underlying subprocess — consistent with the existing pull sheet; worth fixing for both together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)