### PR TITLE
Add Sparkle auto-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,7 @@ jobs:
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       NOTARY_APPLE_ID: ${{ secrets.APPLE_ID }}
       NOTARY_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-      # Sparkle EdDSA private key (base64). Optional — when absent the release
-      # still ships a DMG, just without an appcast for auto-update.
+      # Optional — when absent the release ships without an appcast.
       SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v4
@@ -87,7 +86,6 @@ jobs:
 
       - name: Build & package DMG
         env:
-          # Monotonic CFBundleVersion so Sparkle can order releases.
           BUILD_NUMBER: ${{ github.run_number }}
         run: scripts/build-release.sh
 
@@ -119,7 +117,6 @@ jobs:
           KEY_FILE="$(mktemp)"
           printf '%s' "$SPARKLE_ED_PRIVATE_KEY" > "$KEY_FILE"
           DMG="dist/ContainerUI-${VERSION}.dmg"
-          # e.g. sparkle:edSignature="…" length="…"
           SIG="$("$SIGN_UPDATE" "$DMG" --ed-key-file "$KEY_FILE")"
           rm -f "$KEY_FILE"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       NOTARY_APPLE_ID: ${{ secrets.APPLE_ID }}
       NOTARY_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      # Sparkle EdDSA private key (base64). Optional — when absent the release
+      # still ships a DMG, just without an appcast for auto-update.
+      SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v4
 
@@ -83,6 +86,9 @@ jobs:
           echo "Imported signing identity: $IDENTITY"
 
       - name: Build & package DMG
+        env:
+          # Monotonic CFBundleVersion so Sparkle can order releases.
+          BUILD_NUMBER: ${{ github.run_number }}
         run: scripts/build-release.sh
 
       - name: Notarize & staple
@@ -98,6 +104,44 @@ jobs:
           cd dist
           shasum -a 256 *.dmg > SHA256SUMS.txt
           cat SHA256SUMS.txt
+
+      - name: Generate Sparkle appcast
+        if: env.SPARKLE_ED_PRIVATE_KEY != ''
+        run: |
+          set -euo pipefail
+          SPARKLE_VERSION=2.9.4
+          curl -fsSL "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz" -o /tmp/sparkle.tar.xz
+          mkdir -p /tmp/sparkle && tar -xf /tmp/sparkle.tar.xz -C /tmp/sparkle
+          SIGN_UPDATE="$(find /tmp/sparkle -name sign_update -type f | head -1)"
+
+          KEY_FILE="$(mktemp)"
+          printf '%s' "$SPARKLE_ED_PRIVATE_KEY" > "$KEY_FILE"
+          DMG="dist/ContainerUI-${VERSION}.dmg"
+          # e.g. sparkle:edSignature="…" length="…"
+          SIG="$("$SIGN_UPDATE" "$DMG" --ed-key-file "$KEY_FILE")"
+          rm -f "$KEY_FILE"
+
+          PUBDATE="$(date -u '+%a, %d %b %Y %H:%M:%S +0000')"
+          DOWNLOAD_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/v${VERSION}/ContainerUI-${VERSION}.dmg"
+          {
+            echo '<?xml version="1.0" encoding="utf-8"?>'
+            echo '<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">'
+            echo '  <channel>'
+            echo '    <title>ContainerUI</title>'
+            echo '    <item>'
+            echo "      <title>${VERSION}</title>"
+            echo "      <pubDate>${PUBDATE}</pubDate>"
+            echo "      <sparkle:version>${GITHUB_RUN_NUMBER}</sparkle:version>"
+            echo "      <sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>"
+            echo '      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>'
+            echo "      <description><![CDATA[<p>ContainerUI ${VERSION}. See the <a href=\"https://github.com/${GITHUB_REPOSITORY}/releases/tag/v${VERSION}\">release notes</a>.</p>]]></description>"
+            echo "      <enclosure url=\"${DOWNLOAD_URL}\" ${SIG} type=\"application/octet-stream\"/>"
+            echo '    </item>'
+            echo '  </channel>'
+            echo '</rss>'
+          } > dist/appcast.xml
+          echo "----- appcast.xml -----"
+          cat dist/appcast.xml
 
       - name: Compose release notes
         run: |
@@ -134,6 +178,7 @@ jobs:
           path: |
             dist/*.dmg
             dist/SHA256SUMS.txt
+            dist/appcast.xml
 
       - name: Publish GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
@@ -145,3 +190,4 @@ jobs:
           files: |
             dist/*.dmg
             dist/SHA256SUMS.txt
+            dist/appcast.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,9 @@ jobs:
           SPARKLE_VERSION=2.9.4
           curl -fsSL "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz" -o /tmp/sparkle.tar.xz
           mkdir -p /tmp/sparkle && tar -xf /tmp/sparkle.tar.xz -C /tmp/sparkle
-          SIGN_UPDATE="$(find /tmp/sparkle -name sign_update -type f | head -1)"
+          # Explicit path: the tarball also ships bin/old_dsa_scripts/sign_update
+          # (legacy DSA), which must NOT be used for EdDSA signing.
+          SIGN_UPDATE=/tmp/sparkle/bin/sign_update
 
           KEY_FILE="$(mktemp)"
           printf '%s' "$SPARKLE_ED_PRIVATE_KEY" > "$KEY_FILE"

--- a/App/ContainerUIApp.swift
+++ b/App/ContainerUIApp.swift
@@ -14,7 +14,6 @@ struct ContainerUIApp: App {
         }
         .windowToolbarStyle(.unified(showsTitle: true))
         .commands {
-            // Adds "Check for Updates…" under the app menu, next to About.
             CommandGroup(after: .appInfo) {
                 CheckForUpdatesView(updater: updater)
             }

--- a/App/ContainerUIApp.swift
+++ b/App/ContainerUIApp.swift
@@ -3,6 +3,7 @@ import SwiftUI
 @main
 struct ContainerUIApp: App {
     @State private var app = AppModel()
+    @StateObject private var updater = UpdaterController()
 
     var body: some Scene {
         // A single main window so the menu bar can re-open it by id.
@@ -13,6 +14,10 @@ struct ContainerUIApp: App {
         }
         .windowToolbarStyle(.unified(showsTitle: true))
         .commands {
+            // Adds "Check for Updates…" under the app menu, next to About.
+            CommandGroup(after: .appInfo) {
+                CheckForUpdatesView(updater: updater)
+            }
             CommandGroup(after: .toolbar) {
                 Button("Refresh") {
                     app.requestRefresh()
@@ -36,6 +41,7 @@ struct ContainerUIApp: App {
         Settings {
             SettingsView()
                 .environment(app)
+                .environmentObject(updater)
         }
     }
 }

--- a/App/SettingsView.swift
+++ b/App/SettingsView.swift
@@ -3,6 +3,7 @@ import AppKit
 
 struct SettingsView: View {
     @Environment(AppModel.self) private var app
+    @EnvironmentObject private var updater: UpdaterController
 
     var body: some View {
         @Bindable var app = app
@@ -40,9 +41,24 @@ struct SettingsView: View {
                     .font(.callout)
                     .foregroundStyle(.secondary)
             }
+
+            Section("Updates") {
+                Toggle("Automatically check for updates", isOn: Binding(
+                    get: { updater.automaticallyChecksForUpdates },
+                    set: { updater.automaticallyChecksForUpdates = $0 }
+                ))
+                HStack {
+                    Button("Check for Updates…") { updater.checkForUpdates() }
+                        .disabled(!updater.canCheckForUpdates)
+                    Spacer()
+                }
+                Text("Updates are downloaded from GitHub Releases and verified with a built-in signing key.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
         }
         .formStyle(.grouped)
-        .frame(width: 500, height: 320)
+        .frame(width: 500, height: 400)
     }
 
     private var statusText: String {

--- a/App/UpdaterController.swift
+++ b/App/UpdaterController.swift
@@ -2,12 +2,8 @@ import Combine
 import Sparkle
 import SwiftUI
 
-/// Owns Sparkle's updater for the app's lifetime and mirrors the pieces SwiftUI
-/// needs to observe (whether a check can run, the auto-check preference).
-///
-/// The feed URL and EdDSA public key live in Info.plist (`SUFeedURL`,
-/// `SUPublicEDKey`); Sparkle reads them at startup. `startingUpdater: true`
-/// kicks off the scheduled background checks per `SUScheduledCheckInterval`.
+/// Owns Sparkle's updater and exposes the bits SwiftUI observes. The feed URL
+/// and EdDSA public key come from Info.plist (`SUFeedURL`, `SUPublicEDKey`).
 @MainActor
 final class UpdaterController: ObservableObject {
     @Published private(set) var canCheckForUpdates = false
@@ -25,20 +21,16 @@ final class UpdaterController: ObservableObject {
             .assign(to: &$canCheckForUpdates)
     }
 
-    /// Presents Sparkle's "checking for updates" UI.
     func checkForUpdates() {
         controller.updater.checkForUpdates()
     }
 
-    /// Bindable preference for the Settings toggle.
     var automaticallyChecksForUpdates: Bool {
         get { controller.updater.automaticallyChecksForUpdates }
         set { controller.updater.automaticallyChecksForUpdates = newValue }
     }
 }
 
-/// The "Check for Updates…" menu command, disabled while a check can't run
-/// (e.g. one is already in progress).
 struct CheckForUpdatesView: View {
     @ObservedObject var updater: UpdaterController
 

--- a/App/UpdaterController.swift
+++ b/App/UpdaterController.swift
@@ -1,0 +1,49 @@
+import Combine
+import Sparkle
+import SwiftUI
+
+/// Owns Sparkle's updater for the app's lifetime and mirrors the pieces SwiftUI
+/// needs to observe (whether a check can run, the auto-check preference).
+///
+/// The feed URL and EdDSA public key live in Info.plist (`SUFeedURL`,
+/// `SUPublicEDKey`); Sparkle reads them at startup. `startingUpdater: true`
+/// kicks off the scheduled background checks per `SUScheduledCheckInterval`.
+@MainActor
+final class UpdaterController: ObservableObject {
+    @Published private(set) var canCheckForUpdates = false
+
+    private let controller: SPUStandardUpdaterController
+
+    init() {
+        controller = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+        controller.updater.publisher(for: \.canCheckForUpdates)
+            .receive(on: RunLoop.main)
+            .assign(to: &$canCheckForUpdates)
+    }
+
+    /// Presents Sparkle's "checking for updates" UI.
+    func checkForUpdates() {
+        controller.updater.checkForUpdates()
+    }
+
+    /// Bindable preference for the Settings toggle.
+    var automaticallyChecksForUpdates: Bool {
+        get { controller.updater.automaticallyChecksForUpdates }
+        set { controller.updater.automaticallyChecksForUpdates = newValue }
+    }
+}
+
+/// The "Check for Updates…" menu command, disabled while a check can't run
+/// (e.g. one is already in progress).
+struct CheckForUpdatesView: View {
+    @ObservedObject var updater: UpdaterController
+
+    var body: some View {
+        Button("Check for Updates…") { updater.checkForUpdates() }
+            .disabled(!updater.canCheckForUpdates)
+    }
+}

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -28,8 +28,6 @@
 	<false/>
 	<key>NSHumanReadableCopyright</key>
 	<string>A SwiftUI GUI for Apple's container tool.</string>
-	<!-- Sparkle auto-update. The feed is the appcast.xml asset attached to the
-	     latest GitHub Release; `releases/latest/download/` is a stable redirect. -->
 	<key>SUFeedURL</key>
 	<string>https://github.com/kylemclaren/container-ui/releases/latest/download/appcast.xml</string>
 	<key>SUPublicEDKey</key>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -28,5 +28,15 @@
 	<false/>
 	<key>NSHumanReadableCopyright</key>
 	<string>A SwiftUI GUI for Apple's container tool.</string>
+	<!-- Sparkle auto-update. The feed is the appcast.xml asset attached to the
+	     latest GitHub Release; `releases/latest/download/` is a stable redirect. -->
+	<key>SUFeedURL</key>
+	<string>https://github.com/kylemclaren/container-ui/releases/latest/download/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>U9EQSg3p7eLXu3zAJ2aQXtklhZPGZAkjSF3Eka4vI2w=</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUScheduledCheckInterval</key>
+	<integer>86400</integer>
 </dict>
 </plist>

--- a/project.yml
+++ b/project.yml
@@ -8,6 +8,11 @@ options:
   groupSortPosition: top
   generateEmptyDirectories: true
 
+packages:
+  Sparkle:
+    url: https://github.com/sparkle-project/Sparkle
+    exactVersion: 2.9.4
+
 settings:
   base:
     # Swift 5 language mode (async/await + Observation still fully available).
@@ -34,6 +39,8 @@ targets:
       - Features
       - DesignSystem
       - path: Resources/Assets.xcassets
+    dependencies:
+      - package: Sparkle
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: dev.kylemclaren.ContainerUI

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -26,6 +26,10 @@ APP_NAME="ContainerUI"     # PRODUCT_NAME → ContainerUI.app
 VOLUME_NAME="ContainerUI"
 
 VERSION="${VERSION:?set VERSION (e.g. VERSION=1.2.0)}"
+# Monotonic build number stamped into CFBundleVersion. Sparkle compares this
+# (sparkle:version) to decide if an update is newer, so it must strictly
+# increase across releases — CI passes the run number; local builds default to 1.
+BUILD_NUMBER="${BUILD_NUMBER:-1}"
 SIGNING_IDENTITY="${SIGNING_IDENTITY:-}"
 TEAM_ID="${TEAM_ID:-}"
 
@@ -52,6 +56,7 @@ if [[ -n "$SIGNING_IDENTITY" ]]; then
     -configuration Release \
     -archivePath "$ARCHIVE" \
     MARKETING_VERSION="$VERSION" \
+    CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
     CODE_SIGN_STYLE=Manual \
     CODE_SIGN_IDENTITY="$SIGNING_IDENTITY" \
     DEVELOPMENT_TEAM="$TEAM_ID"
@@ -81,6 +86,7 @@ else
     -configuration Release \
     -archivePath "$ARCHIVE" \
     MARKETING_VERSION="$VERSION" \
+    CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
     CODE_SIGNING_ALLOWED=NO
   mkdir -p "$EXPORT_DIR"
   cp -R "$ARCHIVE/Products/Applications/$APP_NAME.app" "$APP_PATH"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -26,9 +26,7 @@ APP_NAME="ContainerUI"     # PRODUCT_NAME → ContainerUI.app
 VOLUME_NAME="ContainerUI"
 
 VERSION="${VERSION:?set VERSION (e.g. VERSION=1.2.0)}"
-# Monotonic build number stamped into CFBundleVersion. Sparkle compares this
-# (sparkle:version) to decide if an update is newer, so it must strictly
-# increase across releases — CI passes the run number; local builds default to 1.
+# Monotonic CFBundleVersion; Sparkle requires it to strictly increase.
 BUILD_NUMBER="${BUILD_NUMBER:-1}"
 SIGNING_IDENTITY="${SIGNING_IDENTITY:-}"
 TEAM_ID="${TEAM_ID:-}"


### PR DESCRIPTION
Wires **Sparkle 2.9.4** (via SPM) into ContainerUI so installed builds update in place, and extends the tagged-release pipeline to publish a signed appcast. No Apple Developer account required — Sparkle uses its own EdDSA signing key.

## What's included
- **`UpdaterController`** wraps `SPUStandardUpdaterController`. **"Check for Updates…"** appears under the app menu (next to About) and in a new Settings **Updates** section with an "automatically check" toggle.
- **`Info.plist`** carries `SUFeedURL` (the `appcast.xml` asset on the latest GitHub Release, via the stable `releases/latest/download/` redirect — no GitHub Pages needed) and `SUPublicEDKey`.
- **`build-release.sh`** stamps a monotonic `CFBundleVersion` (`BUILD_NUMBER`) so Sparkle can order releases; CI passes `github.run_number`.
- **`release.yml`** signs the DMG with Sparkle's `sign_update` and uploads `appcast.xml` as a release asset — gated on a `SPARKLE_ED_PRIVATE_KEY` secret. Absent secret → release still ships, just without auto-update.

## Verification
- App builds with `Sparkle.framework` embedded and linked; `SUFeedURL`/`SUPublicEDKey` confirmed present in the **built** product's Info.plist.
- Feed uses a stable per-version download URL for the enclosure while the feed itself resolves via `releases/latest`.
- Ran an adversarial multi-agent review of the app wiring, appcast pipeline, and update semantics.

## Two manual steps to light it up (require your credentials)
1. **Set the signing secret.** A Sparkle EdDSA keypair was generated; the public key is baked into `Info.plist`. Add the private key as a repo secret `SPARKLE_ED_PRIVATE_KEY` (command provided separately). For stronger provenance you can instead run Sparkle's `generate_keys` yourself and swap the one public-key value.
2. **Cut a release** (e.g. `v0.4.0`) after merging — the first Sparkle-enabled release produces the initial `appcast.xml`. (Users on v0.3.0 have no updater yet, so auto-update begins from this release forward.)

A **Homebrew cask** + tap (`kylemclaren/homebrew-tap`) is prepared separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)