### PR TITLE
Fix: Sparkle Info.plist keys stripped from released apps

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -28,12 +28,12 @@
 	<false/>
 	<key>NSHumanReadableCopyright</key>
 	<string>A SwiftUI GUI for Apple's container tool.</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
 	<key>SUFeedURL</key>
 	<string>https://github.com/kylemclaren/container-ui/releases/latest/download/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>U9EQSg3p7eLXu3zAJ2aQXtklhZPGZAkjSF3Eka4vI2w=</string>
-	<key>SUEnableAutomaticChecks</key>
-	<true/>
 	<key>SUScheduledCheckInterval</key>
 	<integer>86400</integer>
 </dict>

--- a/project.yml
+++ b/project.yml
@@ -65,6 +65,12 @@ targets:
         NSHumanReadableCopyright: "A SwiftUI GUI for Apple's container tool."
         # Menu-bar/dock app (not an agent).
         LSUIElement: false
+        # Sparkle auto-update — must live here: xcodegen regenerates Info.plist
+        # from these properties, dropping any keys added to the file directly.
+        SUFeedURL: "https://github.com/kylemclaren/container-ui/releases/latest/download/appcast.xml"
+        SUPublicEDKey: "U9EQSg3p7eLXu3zAJ2aQXtklhZPGZAkjSF3Eka4vI2w="
+        SUEnableAutomaticChecks: true
+        SUScheduledCheckInterval: 86400
 
   ContainerUITests:
     type: bundle.unit-test


### PR DESCRIPTION
## Root cause

XcodeGen **regenerates `Resources/Info.plist` from `project.yml`'s `info.properties`** on every `xcodegen generate`. The Sparkle keys (`SUFeedURL`, `SUPublicEDKey`, …) were only added to the plist file directly, so every `xcodegen generate` silently stripped them. CI runs `xcodegen generate` before building, so **every released app (v0.3.1, v0.3.2) shipped with no Sparkle configuration at all** — no feed URL, no public key. That's why auto-update failed to validate.

Verified by mounting the shipped v0.3.2 DMG: its `Info.plist` has no `SUPublicEDKey`/`SUFeedURL`.

## Fix

Declare the Sparkle keys in `project.yml`'s `info.properties` so they survive generation. Verified: after the change, `xcodegen generate` keeps the keys, and a built product's Info.plist carries `SUPublicEDKey = U9EQ…` and the feed URL.

## After merge
Cut **v0.3.3** — the first release whose shipped app actually contains the Sparkle config, signed by the (now-correct) key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)