### PR TITLE
Add private registry login + registry-aware pull

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -59,6 +59,9 @@ final class AppModel {
     /// True while a service start/stop initiated from the menu bar is in flight.
     private(set) var isMutatingService = false
 
+    /// Normalized logged-in registry hosts. nil = unknown (list failed / no CLI).
+    private(set) var loggedInRegistries: Set<String>?
+
     @ObservationIgnored private var monitorTask: Task<Void, Never>?
 
     /// User override for the binary path (persisted). Empty means "auto-detect".
@@ -88,6 +91,7 @@ final class AppModel {
     var systemService: SystemService? { cli.map(SystemService.init) }
     var volumeService: VolumeService? { cli.map(VolumeService.init) }
     var networkService: NetworkService? { cli.map(NetworkService.init) }
+    var registryService: RegistryService? { cli.map(RegistryService.init) }
 
     /// Docker Hub image search talks to the network directly (the CLI has no
     /// registry-search command), so it's available regardless of the backend.
@@ -310,5 +314,12 @@ final class AppModel {
 
     func select(_ item: SidebarItem) {
         withAnimation(Theme.Motion.smooth) { selection = item }
+    }
+
+    /// Refreshes the logged-in registry set from `registry list --quiet`.
+    /// Any failure degrades to nil (unknown) so the pull hint never falsely nags.
+    func refreshRegistries() async {
+        guard let registryService else { loggedInRegistries = nil; return }
+        loggedInRegistries = try? await registryService.loggedInHosts()
     }
 }

--- a/Core/Models/RegistryLogin.swift
+++ b/Core/Models/RegistryLogin.swift
@@ -1,8 +1,12 @@
 import Foundation
 
 /// One stored registry credential, as listed by `container registry list`.
-/// JSON keys are unverified (the CLI returns `[]` when empty), so decoding is
-/// tolerant of `hostname`/`host`/`server` and `username`/`user`.
+///
+/// The shipping CLI emits `name`/`id` for the host and `creationDate`/
+/// `modificationDate` for the timestamps (verified against `registry list
+/// --format json`). Decoding stays tolerant of the older `hostname`/`host`/
+/// `server`, `created`/`modified`, and `user` spellings so a key rename degrades
+/// gracefully instead of crashing the list.
 struct RegistryLogin: Identifiable, Sendable, Equatable {
     var hostname: String
     var username: String?
@@ -13,24 +17,31 @@ struct RegistryLogin: Identifiable, Sendable, Equatable {
 
 extension RegistryLogin: Decodable {
     private enum CodingKeys: String, CodingKey {
-        case hostname, host, server
+        case hostname, name, id, host, server
         case username, user
-        case created, modified
+        case created, creationDate
+        case modified, modificationDate
     }
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        let host = try c.decodeIfPresent(String.self, forKey: .hostname)
-            ?? c.decodeIfPresent(String.self, forKey: .host)
-            ?? c.decodeIfPresent(String.self, forKey: .server)
-        guard let host, !host.isEmpty else {
+        // First key that's present wins (a long `??` chain trips the type-checker).
+        func first(_ keys: CodingKeys...) throws -> String? {
+            for key in keys where try c.decodeIfPresent(String.self, forKey: key) != nil {
+                return try c.decodeIfPresent(String.self, forKey: key)
+            }
+            return nil
+        }
+        // Real CLI keys (`name`/`id`) first, then the older guessed spellings.
+        guard let host = try first(.hostname, .name, .id, .host, .server), !host.isEmpty else {
             throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath,
-                debugDescription: "RegistryLogin has no hostname/host/server key"))
+                debugDescription: "RegistryLogin has no name/id/hostname key"))
         }
         hostname = host
-        username = try c.decodeIfPresent(String.self, forKey: .username)
-            ?? c.decodeIfPresent(String.self, forKey: .user)
-        created = try c.decodeIfPresent(Date.self, forKey: .created)
-        modified = try c.decodeIfPresent(Date.self, forKey: .modified)
+        username = try first(.username, .user)
+        created = try c.decodeIfPresent(Date.self, forKey: .creationDate)
+            ?? c.decodeIfPresent(Date.self, forKey: .created)
+        modified = try c.decodeIfPresent(Date.self, forKey: .modificationDate)
+            ?? c.decodeIfPresent(Date.self, forKey: .modified)
     }
 }
 

--- a/Core/Models/RegistryLogin.swift
+++ b/Core/Models/RegistryLogin.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// One stored registry credential, as listed by `container registry list`.
+/// JSON keys are unverified (the CLI returns `[]` when empty), so decoding is
+/// tolerant of `hostname`/`host`/`server` and `username`/`user`.
+struct RegistryLogin: Identifiable, Sendable, Equatable {
+    var hostname: String
+    var username: String?
+    var created: Date?
+    var modified: Date?
+    var id: String { hostname }
+}
+
+extension RegistryLogin: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case hostname, host, server
+        case username, user
+        case created, modified
+    }
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let host = try c.decodeIfPresent(String.self, forKey: .hostname)
+            ?? c.decodeIfPresent(String.self, forKey: .host)
+            ?? c.decodeIfPresent(String.self, forKey: .server)
+        guard let host, !host.isEmpty else {
+            throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath,
+                debugDescription: "RegistryLogin has no hostname/host/server key"))
+        }
+        hostname = host
+        username = try c.decodeIfPresent(String.self, forKey: .username)
+            ?? c.decodeIfPresent(String.self, forKey: .user)
+        created = try c.decodeIfPresent(Date.self, forKey: .created)
+        modified = try c.decodeIfPresent(Date.self, forKey: .modified)
+    }
+}
+
+/// Canonicalizes registry hostnames so Docker Hub's aliases collapse to one key.
+enum RegistryHost {
+    static let canonicalDockerHub = "docker.io"
+    static let dockerHubAliases: Set<String> = [
+        "docker.io", "index.docker.io", "registry-1.docker.io", "registry.hub.docker.com",
+    ]
+    static func normalize(_ raw: String?) -> String {
+        guard let raw, !raw.trimmingCharacters(in: .whitespaces).isEmpty else { return canonicalDockerHub }
+        let lower = raw.trimmingCharacters(in: .whitespaces).lowercased()
+        return dockerHubAliases.contains(lower) ? canonicalDockerHub : lower
+    }
+    static func forReference(_ reference: String) -> String {
+        normalize(ImageReference.parse(reference).registry)
+    }
+    static func isDockerHub(_ normalizedHost: String) -> Bool { normalizedHost == canonicalDockerHub }
+}

--- a/Core/Services/RegistryService.swift
+++ b/Core/Services/RegistryService.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// TLS scheme for `registry login`. `.auto` omits the flag (CLI default).
+enum RegistryScheme: String, Sendable, CaseIterable {
+    case auto, https, http
+    var flagValue: String? { self == .auto ? nil : rawValue }
+}
+
+/// Registry credential management (`container registry …`).
+struct RegistryService: Sendable {
+    let cli: ContainerCLI
+    init(cli: ContainerCLI) { self.cli = cli }
+
+    // MARK: Argument builders (pure, unit-tested)
+    // NOTE: the password is NEVER an argument — it is piped via stdin.
+    static func loginArguments(server: String, username: String?, scheme: RegistryScheme = .auto) -> [String] {
+        var args = ["registry", "login"]
+        if let s = scheme.flagValue { args += ["--scheme", s] }
+        if let username, !username.isEmpty { args += ["--username", username] }
+        args.append("--password-stdin")
+        args.append(server)
+        return args
+    }
+    static func logoutArguments(server: String) -> [String] { ["registry", "logout", server] }
+    static func listArguments() -> [String] { ["registry", "list", "--format", "json"] }
+    static func listQuietArguments() -> [String] { ["registry", "list", "--quiet"] }
+
+    // MARK: Operations
+    /// Logs in, piping the password/token to stdin (`--password-stdin`).
+    /// The password is passed only as stdin `Data`, never in `arguments`.
+    func login(server: String, username: String, password: String, scheme: RegistryScheme = .auto) async throws {
+        let args = Self.loginArguments(server: server, username: username, scheme: scheme)
+        _ = try await cli.output(args, stdin: Data(password.utf8))
+    }
+    @discardableResult
+    func logout(server: String) async throws -> String {
+        try await cli.text(Self.logoutArguments(server: server))
+    }
+    func list() async throws -> [RegistryLogin] {
+        try await cli.decode([RegistryLogin].self, from: Self.listArguments())
+    }
+    func loggedInHosts() async throws -> Set<String> {
+        let out = try await cli.text(Self.listQuietArguments())
+        let hosts = out.split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .map { RegistryHost.normalize($0) }
+        return Set(hosts)
+    }
+}

--- a/Core/Services/RegistryService.swift
+++ b/Core/Services/RegistryService.swift
@@ -39,12 +39,19 @@ struct RegistryService: Sendable {
     func list() async throws -> [RegistryLogin] {
         try await cli.decode([RegistryLogin].self, from: Self.listArguments())
     }
-    func loggedInHosts() async throws -> Set<String> {
+    /// Hostnames exactly as the CLI stored them — used for display and for
+    /// `logout(server:)`, which must pass the verbatim stored name (no alias
+    /// folding or lowercasing, or the logout won't match the credential).
+    func loggedInHostsRaw() async throws -> [String] {
         let out = try await cli.text(Self.listQuietArguments())
-        let hosts = out.split(separator: "\n")
+        return out.split(separator: "\n")
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
-            .map { RegistryHost.normalize($0) }
-        return Set(hosts)
+    }
+
+    /// Normalized set of logged-in hosts (Docker Hub aliases folded) — the
+    /// authoritative membership check for the pull hint.
+    func loggedInHosts() async throws -> Set<String> {
+        Set(try await loggedInHostsRaw().map(RegistryHost.normalize))
     }
 }

--- a/Features/Explore/ExploreScreen.swift
+++ b/Features/Explore/ExploreScreen.swift
@@ -32,7 +32,10 @@ struct ExploreScreen: View {
         }
         .sheet(item: $pullTarget) { target in
             if let imageService = app.imageService {
+                // Re-inject AppModel: PullImageView reads it (registry-aware hint),
+                // and sheet content doesn't inherit it reliably across the boundary.
                 PullImageView(service: imageService, initialReference: target.reference) {}
+                    .environment(app)
             }
         }
     }

--- a/Features/Images/ImagesScreen.swift
+++ b/Features/Images/ImagesScreen.swift
@@ -45,6 +45,7 @@ struct ImagesScreen: View {
         }
         .sheet(isPresented: $showPull) {
             PullImageView(service: model.service) { await model.load() }
+                .environment(app)
         }
         .sheet(isPresented: $showBuild) {
             BuildImageView(service: model.service) { await model.load() }

--- a/Features/Images/PullImageView.swift
+++ b/Features/Images/PullImageView.swift
@@ -8,6 +8,7 @@ struct PullImageView: View {
     var onComplete: () async -> Void
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(AppModel.self) private var app
 
     @State private var reference: String
     @State private var lines: [String] = []
@@ -17,6 +18,7 @@ struct PullImageView: View {
     @State private var finished = false
     @State private var errorMessage: String?
     @State private var showConsole = false
+    @State private var showLogin = false
 
     init(service: ImageService, initialReference: String = "", onComplete: @escaping () async -> Void) {
         self.service = service
@@ -30,6 +32,13 @@ struct PullImageView: View {
             Divider()
             VStack(alignment: .leading, spacing: 14) {
                 inputRow
+                if let host = loginHintHost {
+                    InlineBanner(kind: .info,
+                        title: "Not signed in to \(host)",
+                        message: "You can still pull public images. Sign in to pull private repositories.",
+                        actionTitle: "Log in",
+                        action: { showLogin = true })
+                }
                 progressCard
                 consoleDisclosure
             }
@@ -40,6 +49,26 @@ struct PullImageView: View {
         .frame(width: 600)
         .fixedSize(horizontal: false, vertical: true)  // hug content; no dead space
         .animation(Theme.Motion.spring, value: showConsole)
+        .sheet(isPresented: $showLogin) {
+            if let service = app.registryService {
+                RegistryLoginView(service: service, initialServer: loginHintHost ?? "") {
+                    await app.refreshRegistries()
+                }
+            }
+        }
+        .task { await app.refreshRegistries() }
+    }
+
+    /// The normalized registry host to nag about, or nil if the reference is
+    /// empty, targets Docker Hub, or the logged-in set isn't known yet.
+    private var loginHintHost: String? {
+        let trimmed = reference.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+        let host = RegistryHost.forReference(trimmed)
+        guard !RegistryHost.isDockerHub(host) else { return nil }
+        guard let known = app.loggedInRegistries else { return nil }
+        guard !known.contains(host) else { return nil }
+        return host
     }
 
     // MARK: - Header / footer

--- a/Features/Registries/RegistriesSection.swift
+++ b/Features/Registries/RegistriesSection.swift
@@ -27,9 +27,13 @@ struct RegistriesSection: View {
             if isLoading {
                 ProgressView().controlSize(.small)
             } else if logins.isEmpty {
-                Text("Not signed in to any registries.")
-                    .font(Theme.Typography.callout)
-                    .foregroundStyle(.secondary)
+                // Only assert "signed in to nothing" when the list actually
+                // succeeded — an error below means we don't really know.
+                if errorMessage == nil {
+                    Text("Not signed in to any registries.")
+                        .font(Theme.Typography.callout)
+                        .foregroundStyle(.secondary)
+                }
             } else {
                 VStack(spacing: 8) {
                     ForEach(logins) { login in
@@ -74,10 +78,14 @@ struct RegistriesSection: View {
     private func reload() async {
         guard let service = app.registryService else { logins = []; return }
         isLoading = logins.isEmpty
+        errorMessage = nil   // a successful refresh must clear any prior error
         defer { isLoading = false }
         do { logins = try await service.list() }
         catch CLIError.decodingFailed {
-            let hosts = (try? await service.loggedInHosts()) ?? []
+            // Decode of the rich JSON failed — fall back to the verbatim hostnames
+            // from `--quiet`. These must NOT be normalized: logout() sends the name
+            // straight to the CLI, which stored it exactly as typed.
+            let hosts = (try? await service.loggedInHostsRaw()) ?? []
             logins = hosts.sorted().map { RegistryLogin(hostname: $0, username: nil, created: nil, modified: nil) }
         }
         catch let e as CLIError { errorMessage = e.localizedDescription }

--- a/Features/Registries/RegistriesSection.swift
+++ b/Features/Registries/RegistriesSection.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+
+/// Embeddable card listing registry logins (`container registry list`), with
+/// log in / log out actions. Used on the System screen.
+struct RegistriesSection: View {
+    @Environment(AppModel.self) private var app
+
+    @State private var logins: [RegistryLogin] = []
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+    @State private var showLogin = false
+    @State private var logoutBusy: Set<String> = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            HStack(spacing: 10) {
+                SectionLabel(title: "Registries")
+                Spacer()
+                PillButton(style: .accent) {
+                    showLogin = true
+                } label: {
+                    Label("Log in", systemImage: "person.badge.key.fill")
+                }
+                .disabled(app.registryService == nil)
+            }
+
+            if isLoading {
+                ProgressView().controlSize(.small)
+            } else if logins.isEmpty {
+                Text("Not signed in to any registries.")
+                    .font(Theme.Typography.callout)
+                    .foregroundStyle(.secondary)
+            } else {
+                VStack(spacing: 8) {
+                    ForEach(logins) { login in
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(login.hostname).font(Theme.Typography.headline)
+                                Text(login.username ?? "—")
+                                    .font(Theme.Typography.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            PillButton(style: .destructive) {
+                                Task { await logout(login.hostname) }
+                            } label: {
+                                if logoutBusy.contains(login.hostname) {
+                                    ProgressView().controlSize(.small)
+                                } else {
+                                    Label("Log out", systemImage: "rectangle.portrait.and.arrow.right")
+                                }
+                            }
+                        }
+                        .card(padding: 14)
+                    }
+                }
+            }
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(Theme.Typography.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+        .sheet(isPresented: $showLogin) {
+            if let service = app.registryService {
+                RegistryLoginView(service: service, initialServer: "") { await reload() }
+            }
+        }
+        .task { await reload() }
+        .onChange(of: app.refreshTick) { Task { await reload() } }
+    }
+
+    private func reload() async {
+        guard let service = app.registryService else { logins = []; return }
+        isLoading = logins.isEmpty
+        defer { isLoading = false }
+        do { logins = try await service.list() }
+        catch CLIError.decodingFailed {
+            let hosts = (try? await service.loggedInHosts()) ?? []
+            logins = hosts.sorted().map { RegistryLogin(hostname: $0, username: nil, created: nil, modified: nil) }
+        }
+        catch let e as CLIError { errorMessage = e.localizedDescription }
+        catch { errorMessage = error.localizedDescription }
+        await app.refreshRegistries()
+    }
+
+    private func logout(_ host: String) async {
+        guard let service = app.registryService else { return }
+        logoutBusy.insert(host)
+        do {
+            _ = try await service.logout(server: host)
+        } catch let e as CLIError {
+            errorMessage = e.localizedDescription
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        logoutBusy.remove(host)
+        await reload()
+    }
+}

--- a/Features/Registries/RegistryLoginView.swift
+++ b/Features/Registries/RegistryLoginView.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+
+/// Sheet for `container registry login`.
+struct RegistryLoginView: View {
+    let service: RegistryService
+    var onDone: () async -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var server: String
+    @State private var username = ""
+    @State private var password = ""
+    @State private var scheme: RegistryScheme = .auto
+    @State private var isWorking = false
+    @State private var errorMessage: String?
+
+    init(service: RegistryService, initialServer: String = "", onDone: @escaping () async -> Void) {
+        self.service = service
+        self.onDone = onDone
+        _server = State(initialValue: initialServer)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                Image(systemName: "person.badge.key.fill")
+                    .font(.system(size: 16))
+                    .foregroundStyle(Color.accentColor)
+                Text("Log in to registry").font(Theme.Typography.title)
+                Spacer()
+                CircleIconButton(systemImage: "xmark", help: "Close", size: 26) { dismiss() }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            Divider()
+
+            VStack(alignment: .leading, spacing: 12) {
+                VStack(alignment: .leading, spacing: 5) {
+                    SectionLabel(title: "Server")
+                    TextField("ghcr.io", text: $server)
+                        .textFieldStyle(.roundedBorder)
+                        .onSubmit { if canSubmit { Task { await submit() } } }
+                }
+                .disabled(isWorking)
+                VStack(alignment: .leading, spacing: 5) {
+                    SectionLabel(title: "Username")
+                    TextField("username", text: $username)
+                        .textFieldStyle(.roundedBorder)
+                        .onSubmit { if canSubmit { Task { await submit() } } }
+                }
+                .disabled(isWorking)
+                VStack(alignment: .leading, spacing: 5) {
+                    SectionLabel(title: "Password or token")
+                    SecureField("password or access token", text: $password)
+                        .textFieldStyle(.roundedBorder)
+                        .onSubmit { if canSubmit { Task { await submit() } } }
+                }
+                .disabled(isWorking)
+                VStack(alignment: .leading, spacing: 5) {
+                    SectionLabel(title: "Scheme")
+                    SegmentedPill(selection: $scheme, options: [
+                        (value: .auto, label: "Auto"),
+                        (value: .https, label: "HTTPS"),
+                        (value: .http, label: "HTTP"),
+                    ])
+                }
+                .disabled(isWorking)
+            }
+            .padding(16)
+
+            Divider()
+            HStack(spacing: 10) {
+                if let errorMessage {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                        .font(Theme.Typography.caption)
+                        .foregroundStyle(.red)
+                        .lineLimit(2)
+                }
+                Spacer()
+                PillButton { dismiss() } label: { Text("Cancel") }
+                PillButton(style: .accent) {
+                    Task { await submit() }
+                } label: {
+                    if isWorking {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Label("Log in", systemImage: "person.badge.key.fill")
+                    }
+                }
+                .disabled(!canSubmit)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+        .frame(width: 480)
+    }
+
+    private var trimmedServer: String { server.trimmingCharacters(in: .whitespaces) }
+    private var trimmedUsername: String { username.trimmingCharacters(in: .whitespaces) }
+
+    private var canSubmit: Bool {
+        !trimmedServer.isEmpty && !trimmedServer.contains(" ")
+            && !trimmedUsername.isEmpty && !password.isEmpty && !isWorking
+    }
+
+    private func submit() async {
+        guard canSubmit else { return }
+        isWorking = true
+        errorMessage = nil
+        defer { isWorking = false }
+        do {
+            try await service.login(server: trimmedServer, username: trimmedUsername, password: password, scheme: scheme)
+            await onDone()
+            dismiss()
+        } catch let error as CLIError {
+            errorMessage = error.localizedDescription
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/Features/System/SystemScreen.swift
+++ b/Features/System/SystemScreen.swift
@@ -87,6 +87,8 @@ struct SystemScreen: View {
                     if let usage = model.diskUsage {
                         diskUsageSection(usage)
                     }
+
+                    RegistriesSection()
                 }
                 .padding(20)
                 .frame(maxWidth: 760, alignment: .leading)

--- a/Tests/ArgumentBuilderTests.swift
+++ b/Tests/ArgumentBuilderTests.swift
@@ -112,6 +112,25 @@ struct ArgumentBuilderTests {
         #expect(ImageService.buildArguments(options) == ["build", "--progress", "plain", "ctx"])
     }
 
+    @Test func registry() {
+        let withUser = RegistryService.loginArguments(server: "ghcr.io", username: "me", scheme: .https)
+        #expect(withUser == ["registry", "login", "--scheme", "https", "--username", "me", "--password-stdin", "ghcr.io"])
+
+        let autoScheme = RegistryService.loginArguments(server: "ghcr.io", username: "me", scheme: .auto)
+        #expect(autoScheme == ["registry", "login", "--username", "me", "--password-stdin", "ghcr.io"])
+
+        let noUser = RegistryService.loginArguments(server: "ghcr.io", username: nil, scheme: .auto)
+        #expect(noUser == ["registry", "login", "--password-stdin", "ghcr.io"])
+
+        for args in [withUser, autoScheme, noUser] {
+            #expect(!args.contains("--password"))
+        }
+
+        #expect(RegistryService.logoutArguments(server: "ghcr.io") == ["registry", "logout", "ghcr.io"])
+        #expect(RegistryService.listArguments() == ["registry", "list", "--format", "json"])
+        #expect(RegistryService.listQuietArguments() == ["registry", "list", "--quiet"])
+    }
+
     @Test func system() {
         #expect(SystemService.statusArguments() == ["system", "status", "--format", "json"])
         #expect(SystemService.dfArguments() == ["system", "df", "--format", "json"])

--- a/Tests/DecodingTests.swift
+++ b/Tests/DecodingTests.swift
@@ -96,10 +96,10 @@ struct DecodingTests {
     func registryListDecodesGuessedKeys() throws {
         let logins = try decoder.decode([RegistryLogin].self, from: Fixtures.data(Fixtures.registryList))
         let login = try #require(logins.first)
-        #expect(login.hostname == "ghcr.io")
-        #expect(login.username == "octocat")
-        #expect(login.created != nil)
-        #expect(login.modified != nil)
+        #expect(login.hostname == "ghcr.io")       // from real CLI `name`/`id`
+        #expect(login.username == "kylemclaren")
+        #expect(login.created != nil)              // from `creationDate`
+        #expect(login.modified != nil)             // from `modificationDate`
     }
 
     @Test("Registry list tolerates alternate key spellings")

--- a/Tests/DecodingTests.swift
+++ b/Tests/DecodingTests.swift
@@ -92,6 +92,26 @@ struct DecodingTests {
         #expect(usage.containers.active == 1)
     }
 
+    @Test("Registry list decodes guessed keys")
+    func registryListDecodesGuessedKeys() throws {
+        let logins = try decoder.decode([RegistryLogin].self, from: Fixtures.data(Fixtures.registryList))
+        let login = try #require(logins.first)
+        #expect(login.hostname == "ghcr.io")
+        #expect(login.username == "octocat")
+        #expect(login.created != nil)
+        #expect(login.modified != nil)
+    }
+
+    @Test("Registry list tolerates alternate key spellings")
+    func registryListToleratesAltKeys() throws {
+        let logins = try decoder.decode([RegistryLogin].self, from: Fixtures.data(Fixtures.registryListAltKeys))
+        let login = try #require(logins.first)
+        #expect(login.hostname == "registry.example.com:5000")
+        #expect(login.username == "deploy")
+        #expect(login.created == nil)
+        #expect(login.modified == nil)
+    }
+
     @Test("Version array has 2 elements up, 1 down")
     func version() throws {
         let up = try decoder.decode([VersionInfo].self, from: Fixtures.data(Fixtures.versionUp))

--- a/Tests/RegistryHostTests.swift
+++ b/Tests/RegistryHostTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+
+/// Verifies registry hostname normalization and reference-derived lookups.
+@Suite("Registry host")
+struct RegistryHostTests {
+    @Test func normalize() {
+        #expect(RegistryHost.normalize("docker.io") == "docker.io")
+        #expect(RegistryHost.normalize("index.docker.io") == "docker.io")
+        #expect(RegistryHost.normalize("registry-1.docker.io") == "docker.io")
+        #expect(RegistryHost.normalize("registry.hub.docker.com") == "docker.io")
+        #expect(RegistryHost.normalize("GHCR.IO") == "ghcr.io")
+        #expect(RegistryHost.normalize("localhost:5000") == "localhost:5000")
+        #expect(RegistryHost.normalize(nil) == "docker.io")
+        #expect(RegistryHost.normalize("") == "docker.io")
+    }
+
+    @Test func forReference() {
+        #expect(RegistryHost.forReference("nginx") == "docker.io")
+        #expect(RegistryHost.forReference("library/alpine") == "docker.io")
+        #expect(RegistryHost.forReference("ghcr.io/owner/repo:tag") == "ghcr.io")
+        #expect(RegistryHost.forReference("localhost:5000/app") == "localhost:5000")
+        #expect(RegistryHost.forReference("docker.io/library/nginx:latest") == "docker.io")
+    }
+}

--- a/Tests/ServiceTests.swift
+++ b/Tests/ServiceTests.swift
@@ -112,6 +112,16 @@ struct ServiceTests {
         #expect(hosts == ["ghcr.io", "docker.io"])
     }
 
+    @Test func loggedInHostsRawPreservesVerbatimSpelling() async throws {
+        // logout(server:) needs the exact stored name — no alias folding/lowercasing.
+        let mock = MockCommandRunner(stdout: "index.docker.io\nGHCR.IO\n\n")
+        let service = RegistryService(cli: .mock(mock))
+
+        let hosts = try await service.loggedInHostsRaw()
+
+        #expect(hosts == ["index.docker.io", "GHCR.IO"])
+    }
+
     @Test func registryListDecodes() async throws {
         let mock = MockCommandRunner(stdout: Fixtures.registryList)
         let service = RegistryService(cli: .mock(mock))
@@ -120,7 +130,7 @@ struct ServiceTests {
 
         #expect(logins.count == 1)
         #expect(logins.first?.hostname == "ghcr.io")
-        #expect(logins.first?.username == "octocat")
+        #expect(logins.first?.username == "kylemclaren")
         #expect(logins.first?.modified != nil)
     }
 }

--- a/Tests/ServiceTests.swift
+++ b/Tests/ServiceTests.swift
@@ -76,4 +76,51 @@ struct ServiceTests {
         #expect(received == ["Pulling...", "Done"])
         #expect(mock.lastArguments == ["image", "pull", "--progress", "plain", "nginx"])
     }
+
+    @Test func loginPassesPasswordViaStdinNotArgs() async throws {
+        let mock = MockCommandRunner()
+        let service = RegistryService(cli: .mock(mock))
+
+        try await service.login(server: "ghcr.io", username: "me", password: "s3cret", scheme: .auto)
+
+        #expect(mock.invocations.last?.standardInput == Data("s3cret".utf8))
+        #expect(mock.lastArguments!.contains("--password-stdin"))
+        #expect(!mock.lastArguments!.contains("s3cret"))
+        #expect(mock.lastArguments!.last == "ghcr.io")
+    }
+
+    @Test func loginPropagatesFailure() async {
+        let mock = MockCommandRunner(stderr: "unauthorized", exitCode: 1)
+        let service = RegistryService(cli: .mock(mock))
+
+        do {
+            try await service.login(server: "ghcr.io", username: "me", password: "s3cret", scheme: .auto)
+            Issue.record("expected login() to throw")
+        } catch is CLIError {
+            // expected
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    @Test func loggedInHostsParsesQuietAndNormalizes() async throws {
+        let mock = MockCommandRunner(stdout: "ghcr.io\nindex.docker.io\n\n")
+        let service = RegistryService(cli: .mock(mock))
+
+        let hosts = try await service.loggedInHosts()
+
+        #expect(hosts == ["ghcr.io", "docker.io"])
+    }
+
+    @Test func registryListDecodes() async throws {
+        let mock = MockCommandRunner(stdout: Fixtures.registryList)
+        let service = RegistryService(cli: .mock(mock))
+
+        let logins = try await service.list()
+
+        #expect(logins.count == 1)
+        #expect(logins.first?.hostname == "ghcr.io")
+        #expect(logins.first?.username == "octocat")
+        #expect(logins.first?.modified != nil)
+    }
 }

--- a/Tests/Support/Fixtures.swift
+++ b/Tests/Support/Fixtures.swift
@@ -190,11 +190,12 @@ enum Fixtures {
     }
     """
 
-    /// `container registry list --format json` — best-guess keys.
+    /// `container registry list --format json` — real shipping-CLI shape
+    /// (host under `name`/`id`, timestamps under `creationDate`/`modificationDate`).
     static let registryList = """
-    [ { "hostname": "ghcr.io", "username": "octocat", "created": "2026-06-01T10:00:00Z", "modified": "2026-06-20T12:30:00Z" } ]
+    [ { "creationDate": "2026-07-05T18:07:01Z", "id": "ghcr.io", "labels": {}, "modificationDate": "2026-07-05T18:07:01Z", "name": "ghcr.io", "username": "kylemclaren" } ]
     """
-    /// Same, exercising the alternate key spellings the binary strings hint at.
+    /// Older/alternate key spellings the tolerant decoder still accepts.
     static let registryListAltKeys = """
     [ { "host": "registry.example.com:5000", "user": "deploy" } ]
     """

--- a/Tests/Support/Fixtures.swift
+++ b/Tests/Support/Fixtures.swift
@@ -190,5 +190,14 @@ enum Fixtures {
     }
     """
 
+    /// `container registry list --format json` — best-guess keys.
+    static let registryList = """
+    [ { "hostname": "ghcr.io", "username": "octocat", "created": "2026-06-01T10:00:00Z", "modified": "2026-06-20T12:30:00Z" } ]
+    """
+    /// Same, exercising the alternate key spellings the binary strings hint at.
+    static let registryListAltKeys = """
+    [ { "host": "registry.example.com:5000", "user": "deploy" } ]
+    """
+
     static func data(_ string: String) -> Data { Data(string.utf8) }
 }


### PR DESCRIPTION
## What

Ship the ability to **authenticate to private registries** from ContainerUI, and make the pull sheet **registry-aware**.

Wraps Apple's `container registry login|logout|list`. Pull from a private registry already worked once you were logged in — this adds the login UI that unlocks it, plus a hint so a private pull doesn't fail cryptically when you're not signed in.

*(Registry **browse** is deliberately out of scope — private registries speak the OCI Distribution API, not Docker Hub's search, so Explore stays Docker-Hub-only.)*

## Changes

**Core**
- `RegistryService` — `login` (password piped via `--password-stdin`, **never** in argv), `logout`, `list` (rich JSON), `loggedInHosts` (from `--quiet`).
- `RegistryLogin` — tolerant `Decodable` (`hostname`/`host`/`server`, `username`/`user`), since `registry list --format json` returns `[]` today and its keys are unverifiable.
- `RegistryHost` — normalizes hosts and folds Docker Hub aliases (`docker.io`, `index.docker.io`, …) to one key.

**App / UI**
- System screen: a **Registries** card — lists logins, log out per row, "Log in" sheet.
- `RegistryLoginView` — server / username / password (SecureField) / scheme sheet, mirroring `CreateVolumeView`.
- Pull sheet: a non-blocking `InlineBanner` — "Not signed in to `ghcr.io`" with a prefilled **Log in** action. Docker Hub / public pulls never nag; the hint **never gates a pull**.

## Design notes

- **The pull hint's source of truth is `--quiet` (hostname-only, format-stable)**, not JSON — so a JSON key rename can't break the safety-critical path. JSON only enriches the management list, and falls back to `--quiet` rows if it fails to decode.
- `loggedInRegistries` is `Set<String>?`: `nil` = unknown ⇒ hint stays silent (fail safe, never a false nag).
- Password sent as stdin `Data` with no trailing newline; not a parameter of any argument builder.

## Testing

- **115 tests pass** (adds registry arg-builder — asserting the password is absent from argv — service, tolerant-decoding, and `RegistryHost` normalization suites).
- `xcodebuild build` clean (per repo convention, the test action skips the SwiftUI app target, so the app target was built separately to catch view compile errors).

Runtime QA against a live private registry (actual login/pull) is worth a manual pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)